### PR TITLE
Início do uso do cmake para compilar o projeto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(SURF)
+set(CMAKE_BUILD_TYPE debug)
+add_definitions(-DGRAPHICS)
+
+
+set(surfLIB main.cpp imload.cpp os_mapping.cpp image.cpp image.h fasthessian.h ipoint.h surf.h imload.h)
+add_library(libSurf.so STATIC ${surfLIB})
+
+
+set(surfEXE match.cpp ${surfLIB})
+add_executable(match.ln ${surfEXE})
+target_link_libraries(match.ln ${libSurf.so})

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@
 # Loads math library.  
 LIBS = -lm
 GET = get
-CFLAGS = -Wall -O3 -DNO_DEBUG -march=pentium4 -mfpmath=sse -mmmx -msse -msse2 -msse3 -ansi
+CFLAGS = -Wall -O3 -DNO_DEBUG -mfpmath=sse -mmmx -msse -msse2 -msse3 -ansi
 DEPEND= makedepend $(CFLAGS)
 
-CC = g++-4.0.2
-CXX = g++-4.0.2
+CC = g++
+CXX = g++
 
 # --------------------- Code modules ----------------------------
 

--- a/image.cpp
+++ b/image.cpp
@@ -1,0 +1,78 @@
+/*
+ * Speeded-Up Robust Features (SURF)
+ * http://people.ee.ethz.ch/~surf
+ *
+ * Authors: Herbert Bay, Andreas Ess, Geert Willems
+ * Windows port by Stefan Saur
+ *
+ * Copyright (2006): ETH Zurich, Switzerland
+ * Katholieke Universiteit Leuven, Belgium
+ * All rights reserved.
+ *
+ * For details, see the paper:
+ * Herbert Bay,  Tinne Tuytelaars,  Luc Van Gool,
+ *  "SURF: Speeded Up Robust Features"
+ * Proceedings of the ninth European Conference on Computer Vision, May 2006
+ *
+ * Permission to use, copy, modify, and distribute this software and
+ * its documentation for educational, research, and non-commercial
+ * purposes, without fee and without a signed licensing agreement, is
+ * hereby granted, provided that the above copyright notice and this
+ * paragraph appear in all copies modifications, and distributions.
+ *
+ * Any commercial use or any redistribution of this software
+ * requires a license from one of the above mentioned establishments.
+ *
+ * For further details, contact Andreas Ess (aess@vision.ee.ethz.ch).
+ */
+
+#include "image.h"
+#include <stdlib.h>
+
+namespace surf {
+	
+Image::Image(const int w, const int h){
+	_height = h;
+	_width = w;
+	allocPixels(w, h);
+	_ref = false;
+}
+
+//! constructor for integral image
+//[TODO] doubleImSize not used, is to double width and height?
+Image::Image(Image *im, bool doubleImSize){
+	allocPixels(im->getHeight(), im->getWidth());
+	double sum = 0;
+	for(int i = 0; i < im->getHeight(); i++){
+		for(int j = 0; j < im->getWidth(); j++){
+			sum += im->getPix(j, i);
+			_pixels[i][j] = sum;
+		}
+	}
+}
+
+
+Image::~Image(){
+	if(_ref == false)
+		delete _pixels;
+}
+
+void Image::allocPixels(int w, int h){
+	//_pixels = new double[h][w];
+	_pixels = (double**)malloc(h*w*sizeof(double));
+}
+
+int Image::getWidth(){
+	return _width;
+}
+
+int Image::getHeight(){
+	return _height;
+}
+
+/*double** Image::getPixels(){
+	return _pixels;
+}*/
+
+}
+

--- a/match.cpp
+++ b/match.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <string>
+#include <string.h>
 #include <iostream>
 #include <fstream>
 #include <cmath>


### PR DESCRIPTION
As funções que implementam o surf estão faltando,
era esperado um arquivo surf.cpp.
O arquivo image.cpp foi criado adivinhando o que
as funções do arquivo image.h desejam.
Ainda falta o arquivo surf.cpp que implementa
as funções do surf propriamente ditas.